### PR TITLE
missing quotes

### DIFF
--- a/magerun
+++ b/magerun
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-sudo -u www-data -- /n98-magerun.phar --root-dir=$MAGE_ROOT_DIR $@
+sudo -u www-data -- /n98-magerun.phar --root-dir=$MAGE_ROOT_DIR "$@"


### PR DESCRIPTION
quotes should be included to correctly pass all arguments so that it would work on command below:

db:query "show tables"